### PR TITLE
Installation with pip in edit mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools >= 64"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tts==0.21.3
+coqui-tts
 pydub
 nltk
 beautifulsoup4

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ ebooklib
 tqdm
 mecab
 mecab-python3
-unidic
+unidic-lite

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+tts==0.21.3
+pydub
+nltk
+beautifulsoup4
+ebooklib
+tqdm
+mecab
+mecab-python3
+unidic

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,22 @@
-impott setuptools
+import subprocess
+from setuptools import setup, find_packages, Command
+
+class InstallExtra(Command):
+    description = 'Install dependencies and download additional resources'
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        # Run the standard installation
+        subprocess.check_call(['pip', 'install', '-r', 'requirements.txt'])
+        # Download unidic and nltk punkt
+        subprocess.check_call(['python', '-m', 'unidic', 'download'])
+        subprocess.check_call(['python', '-m', 'nltk.downloader', 'punkt'])
 
 with open("README.md", "r", encoding='utf-8') as fh:
     long_description = fh.read()
@@ -7,7 +25,7 @@ with open("README.md", "r", encoding='utf-8') as fh:
 with open('requirements.txt') as f:
     requirements = f.read().splitlines()
 
-setuptools.setup(
+setup(
     name="ebook2audiobookXTTS",
     version="1.2",
     author="Drew Thomasson",
@@ -15,10 +33,9 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/DrewThomasson/ebook2audiobookXTTS",
-    packages=setuptools.find_packages(),
+    packages=find_packages(),
     entry_points={
         'console_scripts': [
-            'turnvoice=turnvoice.core.turnvoice:main',
             'ebook2audiobook=ebook2audiobook:main',
         ],
     },
@@ -29,6 +46,6 @@ setuptools.setup(
     ],
     python_requires='>=3.10',
     install_requires=requirements,
-    keywords='replace, voice, ebook, audiobook, '
-             'sentence-segmentation, TTS-engine, sentence-fragment, python'
+    keywords='ebook, audiobook, '
+             'TTS-engine, python'
 )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import subprocess
 from setuptools import setup, find_packages, Command
 
-class InstallExtra(Command):
+class InstallPackages(Command):
     description = 'Install dependencies and download additional resources'
     user_options = []
 
@@ -12,9 +12,7 @@ class InstallExtra(Command):
         pass
 
     def run(self):
-        # Run the standard installation
         subprocess.check_call(['pip', 'install', '-r', 'requirements.txt'])
-        # Download unidic and nltk punkt
         subprocess.check_call(['python', '-m', 'unidic', 'download'])
         subprocess.check_call(['python', '-m', 'nltk.downloader', 'punkt'])
 
@@ -30,8 +28,6 @@ setup(
     version="1.2",
     author="Drew Thomasson",
     description="Convert eBooks to audiobooks with chapters and metadata.",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
     url="https://github.com/DrewThomasson/ebook2audiobookXTTS",
     packages=find_packages(),
     entry_points={
@@ -44,6 +40,9 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
+    cmdclass={
+        'install': InstallPackages,
+    }
     python_requires='>=3.10',
     install_requires=requirements,
     keywords='ebook, audiobook, '

--- a/setup.py
+++ b/setup.py
@@ -1,50 +1,48 @@
-import subprocess
-from setuptools import setup, find_packages, Command
+import os
+from setuptools import setup, find_packages
+from setuptools.command.develop import develop
+from setuptools.command.install import install
 
-class InstallPackages(Command):
-    description = 'Install dependencies and download additional resources'
-    user_options = []
 
-    def initialize_options(self):
-        pass
-
-    def finalize_options(self):
-        pass
-
-    def run(self):
-        subprocess.check_call(['pip', 'install', '-r', 'requirements.txt'])
-        subprocess.check_call(['python', '-m', 'unidic', 'download'])
-        subprocess.check_call(['python', '-m', 'nltk.downloader', 'punkt'])
+cwd = os.path.dirname(os.path.abspath(__file__))
 
 with open("README.md", "r", encoding='utf-8') as fh:
     long_description = fh.read()
-
-# Read requirements.txt
 with open('requirements.txt') as f:
     requirements = f.read().splitlines()
+class PostInstallCommand(install):
+    """Post-installation for installation mode."""
+    def run(self):
+        install.run(self)
+        os.system('python -m unidic download')
+
+
+class PostDevelopCommand(develop):
+    """Post-installation for development mode."""
+    def run(self):
+        develop.run(self)
+        os.system('python -m unidic download')
 
 setup(
-    name="ebook2audiobookXTTS",
-    version="1.2",
+    name='ebook2audiobookXTTS',
+    version='1.2.0',
     author="Drew Thomasson",
-    description="Convert eBooks to audiobooks with chapters and metadata.",
+    description="Convert eBooks to audiobooks with chapters and metadata",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     url="https://github.com/DrewThomasson/ebook2audiobookXTTS",
     packages=find_packages(),
-    entry_points={
-        'console_scripts': [
-            'ebook2audiobook=ebook2audiobook:main',
-        ],
-    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    cmdclass={
-        'install': InstallPackages,
-    },
-    python_requires='>=3.10',
+    include_package_data=True,
     install_requires=requirements,
-    keywords='ebook, audiobook, '
-             'TTS-engine, python'
+    entry_points={
+        "console_scripts": [
+            "ebook2audiobook = app:main",
+        ],
+    },
+    keywords='ebook, audiobook, TTS-engine, python',
 )

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     ],
     cmdclass={
         'install': InstallPackages,
-    }
+    },
     python_requires='>=3.10',
     install_requires=requirements,
     keywords='ebook, audiobook, '

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,34 @@
+impott setuptools
+
+with open("README.md", "r", encoding='utf-8') as fh:
+    long_description = fh.read()
+
+# Read requirements.txt
+with open('requirements.txt') as f:
+    requirements = f.read().splitlines()
+
+setuptools.setup(
+    name="ebook2audiobookXTTS",
+    version="1.2",
+    author="Drew Thomasson",
+    description="Convert eBooks to audiobooks with chapters and metadata.",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/DrewThomasson/ebook2audiobookXTTS",
+    packages=setuptools.find_packages(),
+    entry_points={
+        'console_scripts': [
+            'turnvoice=turnvoice.core.turnvoice:main',
+            'ebook2audiobook=ebook2audiobook:main',
+        ],
+    },
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    python_requires='>=3.10',
+    install_requires=requirements,
+    keywords='replace, voice, ebook, audiobook, '
+             'sentence-segmentation, TTS-engine, sentence-fragment, python'
+)


### PR DESCRIPTION
Added files to let the user/developer to install in edit mode (pip install -e .)
- setup.py
- requirements.txt
- pyproject.toml

IMPORTANT: if the app.py is still the script to run it should contain a "__main__" function, otherwise it will be not possible to
call directly ebook2audiobookXTTS as an app name.

Worth to advise the user/develpoer to install a virtual python env v3.10 min, v3.11 max, with for i.e. conda
(I tried with python 3.11 and everything is ok)
conda create --prefix /path/to/env-folder python=3.11
conda activate  /path/to/env-folder
...
conda deactivate